### PR TITLE
Feat: 실시간 주식 차트 매매 서버에 kafka 데이터 전송

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,10 @@ dependencies {
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
+    //Kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/tmt/realtimechartservice/chart/service/KafkaProducerService.java
+++ b/src/main/java/tmt/realtimechartservice/chart/service/KafkaProducerService.java
@@ -1,0 +1,5 @@
+package tmt.realtimechartservice.chart.service;
+
+public interface KafkaProducerService {
+	void sendTrade(String message);
+}

--- a/src/main/java/tmt/realtimechartservice/chart/service/KafkaProducerServiceImp.java
+++ b/src/main/java/tmt/realtimechartservice/chart/service/KafkaProducerServiceImp.java
@@ -1,0 +1,19 @@
+package tmt.realtimechartservice.chart.service;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class KafkaProducerServiceImp implements KafkaProducerService{
+
+	private final KafkaTemplate<String, String> kafkaTemplate;
+
+	public KafkaProducerServiceImp(KafkaTemplate<String, String> kafkaTemplate) {
+		this.kafkaTemplate = kafkaTemplate;
+	}
+
+	@Override
+	public void sendTrade(String message) {
+		kafkaTemplate.send("realchart-trade-stockinfo", message);
+	}
+}

--- a/src/main/java/tmt/realtimechartservice/chart/service/ReactiveRedisService.java
+++ b/src/main/java/tmt/realtimechartservice/chart/service/ReactiveRedisService.java
@@ -4,5 +4,6 @@ import reactor.core.publisher.Mono;
 
 public interface ReactiveRedisService {
 	Mono<Void> save(String key, String value);
-	Mono<String> get(String key);
+	Mono<String> getPrice(String key);
+	Mono<String> getAskPrice(String key);
 }

--- a/src/main/java/tmt/realtimechartservice/chart/service/ReactiveRedisServiceImp.java
+++ b/src/main/java/tmt/realtimechartservice/chart/service/ReactiveRedisServiceImp.java
@@ -9,19 +9,25 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class ReactiveRedisServiceImp implements ReactiveRedisService {
 
-	private static final String REDIS_KEY_PREFIX = "stock:";
+	private static final String PRICE_PREFIX = "stock:";
+	private static final String ASKING_PRICE_PREFIX = "stock:askPrice-";
 	private static final String CHANNEL = "reactive_stock";
 
 	private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
 
 	@Override
 	public Mono<Void> save(String key, String value) {
-		return reactiveRedisTemplate.opsForValue().set(REDIS_KEY_PREFIX + key, value)
-				.then(reactiveRedisTemplate.convertAndSend(CHANNEL, REDIS_KEY_PREFIX + key + ":" + value).then());
+		return reactiveRedisTemplate.opsForValue().set(PRICE_PREFIX + key, value)
+				.then(reactiveRedisTemplate.convertAndSend(CHANNEL, PRICE_PREFIX + key + ":" + value).then());
 	}
 
 	@Override
-	public Mono<String> get(String key) {
-		return reactiveRedisTemplate.opsForValue().get(REDIS_KEY_PREFIX + key);
+	public Mono<String> getPrice(String key) {
+		return reactiveRedisTemplate.opsForValue().get(PRICE_PREFIX + key);
+	}
+
+	@Override
+	public Mono<String> getAskPrice(String key) {
+		return reactiveRedisTemplate.opsForValue().get(ASKING_PRICE_PREFIX + key);
 	}
 }

--- a/src/main/java/tmt/realtimechartservice/chart/service/RedisPubSubServiceImp.java
+++ b/src/main/java/tmt/realtimechartservice/chart/service/RedisPubSubServiceImp.java
@@ -1,16 +1,22 @@
 package tmt.realtimechartservice.chart.service;
 
 import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.ReactiveRedisMessageListenerContainer;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Sinks;
 
+@Slf4j
 @Service
 public class RedisPubSubServiceImp implements RedisPubSubService {
 
 	private final Sinks.Many<String> sink;
+
+	@Autowired
+	private ReactiveRedisService reactiveRedisService;
 
 	public RedisPubSubServiceImp(ReactiveRedisMessageListenerContainer listenerContainer) {
 		this.sink = Sinks.many().multicast().directAllOrNothing();
@@ -24,17 +30,20 @@ public class RedisPubSubServiceImp implements RedisPubSubService {
 
 	@Override
 	public Flux<String> getRealTimePrice(String stockCode) {
-		return sink.asFlux()
-				.filter(message -> message.startsWith("stock:" + stockCode))
-				.mergeWith(Flux.interval(Duration.ofSeconds(10)).map(tick -> "keep-alive"))
-				.doOnCancel(() -> System.out.println("Client disconnected")); // 클라이언트 연결 해제 시 로그 출력
+		return reactiveRedisService.getPrice(stockCode)
+				.concatWith(sink.asFlux()
+						.filter(message -> message.startsWith("stock:" + stockCode))
+						.mergeWith(Flux.interval(Duration.ofSeconds(10)).map(tick -> "keep-alive"))
+						.doOnCancel(() -> log.info("Price Client disconnected"))); // 클라이언트 연결 해제 시 로그 출력)
+
 	}
 
 	@Override
 	public Flux<String> getAskPrice(String stockCode) {
-		return sink.asFlux()
-				.filter(message -> message.startsWith("stock:askPrice-" + stockCode))
-				.mergeWith(Flux.interval(Duration.ofSeconds(10)).map(tick -> "keep-alive"))
-				.doOnCancel(() -> System.out.println("Client disconnected"));
+		return reactiveRedisService.getAskPrice(stockCode)
+				.concatWith(sink.asFlux()
+						.filter(message -> message.startsWith("stock:askPrice-" + stockCode))
+						.mergeWith(Flux.interval(Duration.ofSeconds(10)).map(tick -> "keep-alive"))
+						.doOnCancel(() -> log.info("Ask Price Client disconnected"))); // 클라이언트 연결 해제 시 로그 출력)
 	}
 }

--- a/src/main/java/tmt/realtimechartservice/global/config/KafkaProducerConfig.java
+++ b/src/main/java/tmt/realtimechartservice/global/config/KafkaProducerConfig.java
@@ -1,0 +1,34 @@
+package tmt.realtimechartservice.global.config;
+
+import org.apache.kafka.common.serialization.StringSerializer;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+@Configuration
+public class KafkaProducerConfig {
+	@Value("${kafka.bootstrap-server}")
+	private String bootstrapServer;
+
+	@Bean
+	public ProducerFactory<String, String> producerFactory(){
+		Map<String, Object> configProps = new HashMap<>();
+		configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
+		configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+		configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+		return new DefaultKafkaProducerFactory<>(configProps);
+	}
+
+	@Bean
+	public KafkaTemplate<String, String> kafkaTemplate(){
+		return new KafkaTemplate<>(producerFactory());
+	}
+
+}


### PR DESCRIPTION
<!-- 제목 : convention: 기능명#issue 번호
  ex) feat : pull request template#17-->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리펙토링
- [ ] 간단 코드 리펙토링 (주석, 코드 컨벤션, 오타 수정 등)
- [ ] 패키징 구조 변경
- [ ] 파일명 변경
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용

<!--@{Issue번호} + Enter
ex) @17
이슈와 PR 연결을 위해 사용합니다!-->
#11 
- 실시간 차트 데이터 매매 서비스로 Kafka Producer 전송
- 실시간 차트 데이터 조회 시 초기값은 레디스 데이터로 부터 조회 후 실시간과 연결
